### PR TITLE
Add leading zeroes, fix digit widths, add formatting passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.dta
 *.xlsx
 *.xls
+distinct.ado
+xcontract.ado
+xcontract.sthlp

--- a/cortable.ado
+++ b/cortable.ado
@@ -1,3 +1,4 @@
+*! v2.0.5  11nov2021  PLakin
 *! v2.0.4  05jul2020  RMedeiros
 *! v2.0.3  25jun2020  RMedeiros
 *! v2.0.2  03jun2020  RMedeiros
@@ -7,7 +8,7 @@
 *! v1.2.0  07sep2019  RMedeiros
 
 program define cortable, rclass
-version 15.1
+version 16.1
 
 syntax varlist(numeric) [if] [in] /// rowvariable list
 	[, ///
@@ -39,6 +40,8 @@ syntax varlist(numeric) [if] [in] /// rowvariable list
 	pdf /// saves to putpdf 
 	docx /// default but can be specified 
 	TABLEOPTions(string) /// options at table creation time 
+	PCTFoverride(string) /// percent format override for cat and binary
+	CONFoverride(string) /// continuous statistics format override
 	]
 	
 local fullcmd `"`0'"'
@@ -134,6 +137,15 @@ else {
 	}
 }
 
+    // PCTFoverride(), CONFoverride() 
+        // table is new until we know otherwise
+if "`pctfoverride'" != "" {
+	di "`pctfoverride' format override specified for categorical statistics."
+}
+
+if "`confoverride'" != "" {
+	di "`confoverride' format override specified for continuous statistics."
+}
 
 if "`na'"=="" {
 	local na n/a
@@ -364,7 +376,9 @@ else {
 		suppress(`suppress') /// when to supress cells for small size 
 		constat("`constat'") /// stats can be anything produced by -summ 
 		tabnumber(`tabnumber') /// table number
-		`header' `addheader'
+		`header' `addheader' ///
+		pctfoverride(`pctfoverride') ///
+		confoverride(`confoverride')
 	local currow = r(currow)
 }
 

--- a/cortable.sthlp
+++ b/cortable.sthlp
@@ -470,7 +470,7 @@ variables
 {title:Author} 
 
 {p 4 4 2}
-Paul Lakin {break}
+Paul R. Lakin {break}
 CorEvitas, LLC {break}
 plakin@corevitas.com
 

--- a/cortable.sthlp
+++ b/cortable.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0  07jul2020}{...}
+{* *! version 2.0.5  11nov2021}{...}
 {vieweralsosee "corrona" "help corrona"}{...}
 {vieweralsosee "corcf" "help corcf"}{...}
 {vieweralsosee "corset" "help corset"}{...}
@@ -78,6 +78,8 @@ suppressed{p_end}
 {synopt :{cmd:counts}}request table containing counts of non-missing 
 observations{p_end}
 {synopt :{cmd:constat(}{it:{help cortable##statname:statname}} [{it:...}]{cmd:)}}statistics for continuous variables{p_end}
+{synopt :{opt confoverride(%fmt)}}override default continuous statistics format to {it:%fmt} {p_end}
+{synopt :{opt pctfoverride(%fmt)}}override default categorical statistics format to {it:%fmt} {p_end}
 
 {syntab :Table header}
 {synopt :{cmdab:headerf:ormat(}{it:{help putdocx##cellfmtopts:cell_fmt_options}}{cmd:)}}options that control the look of cell contents in first row{p_end}
@@ -286,7 +288,7 @@ default is {cmd:msd}.  Available statistics are
 {synopt:{space 4}{opt mean}}mean{p_end}
 {synopt:{space 4}{opt sd}}standard deviation{p_end}
 {synopt:{space 4}{opt msd}}mean with standard deviation (mean +/- s.d.){p_end}
-{synopt:{space 4}{opt variance}}variance{p_end}
+{synopt:{space 4}{opt Var}}variance{p_end}
 {synopt:{space 4}{opt skewness}}skewness{p_end}
 {synopt:{space 4}{opt kurtosis}}kurtosis{p_end}
 {synopt:{space 4}{opt median}}median (same as {opt p50}){p_end}
@@ -468,14 +470,9 @@ variables
 {title:Author} 
 
 {p 4 4 2}
-Rose Medeiros {break}
-Corrona, LLC {break}
-rmedeiros@corrona.org
-
-{p 4 4 2}
-Rebecca Raciborski {break}
-Corrona, LLC {break}
-rraciborski@corrona.org
+Paul Lakin {break}
+CorEvitas, LLC {break}
+plakin@corevitas.com
 
 {title:Also see}
 


### PR DESCRIPTION
Added pctfoverride option,
Added confoverride option,
-> cortable version to 2.0.5
Added documentation of these options
Fixed documentation of Var "variance" option to conform to Stata <sum> command standards
Updated maintainer name and contact information
Catch formatting throughout cortable_split to catch statistics with absolute value < 1 and print them with leading zeroes
Add overrides throughout cortable_split to override default formats